### PR TITLE
Drop functions by full signature to support overloads

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -15220,22 +15220,27 @@ async function run2(c) {
 // src/functions.mjs
 var core3 = __toModule(require_core());
 var publicFunctions = `SELECT
-    routine_name
-FROM 
-    information_schema.routines
-WHERE 
-    routine_type = 'FUNCTION'
+    n.nspname AS schema_name,
+    p.proname AS function_name,
+    pg_get_function_identity_arguments(p.oid) AS args
+FROM
+    pg_proc p
+JOIN
+    pg_namespace n ON n.oid = p.pronamespace
+WHERE
+    n.nspname = 'public'
 AND
-    routine_schema = 'public';
+    p.prokind = 'f';
 `;
-async function dropFunction(name, c) {
-  core3.info(`Drop Function: ${name}`);
-  return c.query(`DROP FUNCTION IF EXISTS "${name}" CASCADE;`);
+async function dropFunction(func, c) {
+  const signature = `"${func.schema_name}"."${func.function_name}"(${func.args})`;
+  core3.info(`Drop Function: ${signature}`);
+  return c.query(`DROP FUNCTION IF EXISTS ${signature} CASCADE;`);
 }
 async function run3(c) {
   const { rows: funcs } = await c.query(publicFunctions);
   await forEachSeries_default(funcs, async (func) => {
-    return dropFunction(func.routine_name, c);
+    return dropFunction(func, c);
   });
 }
 

--- a/src/functions.mjs
+++ b/src/functions.mjs
@@ -2,27 +2,30 @@ import * as core from '@actions/core';
 import { forEachSeries } from 'modern-async';
 
 const publicFunctions = `SELECT
-    routine_name
-FROM 
-    information_schema.routines
-WHERE 
-    routine_type = 'FUNCTION'
+    n.nspname AS schema_name,
+    p.proname AS function_name,
+    pg_get_function_identity_arguments(p.oid) AS args
+FROM
+    pg_proc p
+JOIN
+    pg_namespace n ON n.oid = p.pronamespace
+WHERE
+    n.nspname = 'public'
 AND
-    routine_schema = 'public';
+    p.prokind = 'f';
 `;
 
-async function dropFunction(name, c) {
-	core.info(`Drop Function: ${name}`);
+async function dropFunction(func, c) {
+	const signature = `"${func.schema_name}"."${func.function_name}"(${func.args})`;
+	core.info(`Drop Function: ${signature}`);
 
-	return c.query(`DROP FUNCTION IF EXISTS "${name}" CASCADE;`)
+	return c.query(`DROP FUNCTION IF EXISTS ${signature} CASCADE;`);
 }
 
 export default async function run(c) {
-	// Find all Functions in the public schema
-	const { rows: funcs }= await c.query(publicFunctions)
-	
-	// Delete all the included functions 
+	const { rows: funcs } = await c.query(publicFunctions);
+
 	await forEachSeries(funcs, async (func) => {
-		return dropFunction(func.routine_name, c);
-	})
+		return dropFunction(func, c);
+	});
 }


### PR DESCRIPTION
## Summary
- Replace `information_schema.routines` enumeration (one row per overload, name-only) with `pg_proc` join on `pg_namespace` that includes the full identity arguments via `pg_get_function_identity_arguments(oid)`.
- Issue `DROP FUNCTION IF EXISTS "schema"."name"(args) CASCADE` per overload so Postgres uniquely resolves each function.

## Why
The previous implementation emitted `DROP FUNCTION IF EXISTS "name" CASCADE` with no argument list. When `public` contained more than one overload of the same name, Postgres aborted with:

```
error: function name "<name>" is not unique
hint: Specify the argument list to select the function unambiguously.
```

(SQLSTATE `42725`, `LookupFuncWithArgs`.) The reset crashed mid-flight on the first overloaded name, leaving the destination DB in an inconsistent state and blocking subsequent migration replay.

Overloads accumulate naturally: any `CREATE OR REPLACE FUNCTION` that changes the parameter list creates a new overload alongside the old one, since `CREATE OR REPLACE` matches on full signature. A successful migration replay against a freshly-reset DB therefore rebuilds every historical signature.

## Test plan
- [ ] Run the action against a project that has at least one overloaded function in `public` (e.g. multiple `admin_update_fleet_location` signatures) and confirm each overload is dropped individually.
- [ ] Confirm no regression on the single-signature path.
- [ ] Tag `v1.8` once merged and verify the consuming workflow's reset step completes.